### PR TITLE
Use platform compatible path separators when creating the parser

### DIFF
--- a/lib/less-middleware.js
+++ b/lib/less-middleware.js
@@ -45,11 +45,11 @@ module.exports = function( publicDirectory ) {
 						}
 
 						// figuring out length of array so i can slice off the last arugement when putting it back together
-						var filePathArrayLength = lessFilePath.split( '/' ).length;
+						var filePathArrayLength = lessFilePath.split( path.sep ).length;
 
 						// creating a less parser with the path that the file was found (for @imports)
 						var parser = new( less.Parser )({
-							paths: [ lessFilePath.split( '/' ).slice( 0, filePathArrayLength - 1 ).join( '/' ) + '/' ]
+							paths: [ lessFilePath.split( path.sep ).slice( 0, filePathArrayLength - 1 ).join( path.sep ) + path.sep ]
 						});
 
 						// parsing the file data we've loaded into css


### PR DESCRIPTION
This fixes breakage on Windows.
